### PR TITLE
create a standalone global tool 'dotnet-signalr-bench'

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,85 @@ This benchmark targets to help you evaluate the throughput and latency. It can b
 - **SignalRServiceBenchmarkPlugin**: The benchmark source code folder which can be run on a single machine with 2 commands. If you want to get a quick start, or check the benchmark source code for further development, please go to this folder.
 
 # Quick start
+
+Run the tool on local machine
+
+## Install and run dotnet-signalr-bench global tool
+
+Install the tool
+
+`dotnet tool install -g dotnet-signalr-bench`
+
+Start the agent
+
+```
+E:\home\Work\SignalRBenchTests>dotnet signalr-bench agent
+[11:51:53 INF] Create Rpc Server...
+[11:51:53 INF] Start server...
+```
+
+Start the application
+
+```
+E:\home\Work\SignalRBenchTests>dotnet signalr-bench application
+use local signalr: True
+Starting serverListening on:
+  http://[::]:5050
+
+Press CTRL+C to exit
+```
+
+Start the controller with 'echo.yaml'. The content of echo.yaml is
+
+```
+mode: simple
+config:
+  webAppTarget: http://localhost:5050/signalrbench
+  connections: 1000
+  baseSending: 500
+  step: 500
+  singleStepDuration: 1000
+  debug: true
+```
+
+```
+E:\home\Work\SignalRBenchTests>dotnet signalr-bench controller -c echo.yaml
+[11:45:04 INF] Open channel to rpc server...
+[11:45:04 INF] Create Rpc client...
+......
+[11:54:38 INF] Stop collecting...
+[11:54:38 INF] -----------
+[11:54:38 INF]   1000 connections established in 9s
+[11:54:38 INF] -----------
+[11:54:38 INF]  Connections/sendingStep: 1000/500 in 5s
+[11:54:38 INF]  Messages: requests: 1.81MB, responses: 1.81MB
+[11:54:38 INF]    Requests/sec: 175.80
+[11:54:38 INF]    Responses/sec: 175.80
+[11:54:38 INF]    Write throughput: 361.44KB
+[11:54:38 INF]    Read throughput: 361.44KB
+[11:54:38 INF]  Latency:
+[11:54:38 INF]   50.00%: < 100 ms
+[11:54:38 INF]   90.00%: < 100 ms
+[11:54:38 INF]   95.00%: < 100 ms
+[11:54:38 INF]   99.00%: < 200 ms
+[11:54:38 INF] -----------
+[11:54:38 INF]  Connections/sendingStep: 1000/1000 in 4s
+[11:54:38 INF]  Messages: requests: 3.67MB, responses: 3.67MB
+[11:54:38 INF]    Requests/sec: 446.00
+[11:54:38 INF]    Responses/sec: 446.00
+[11:54:38 INF]    Write throughput: 916.98KB
+[11:54:38 INF]    Read throughput: 916.98KB
+[11:54:38 INF]  Latency:
+[11:54:38 INF]   50.00%: < 100 ms
+[11:54:38 INF]   90.00%: < 100 ms
+[11:54:38 INF]   95.00%: < 100 ms
+[11:54:38 INF]   99.00%: < 100 ms
+[11:54:38 INF] Handle step...
+```
+## Run the self build benchmark
+
+You can build and run the source code by yourself.
+
 ![quickstart.git](Doc/quickrun.gif)
 Take 1000 connections for `Echo` performance test as an example.
 

--- a/SignalRServiceBenchmarkPlugin/SignalRServiceBenchmark.sln
+++ b/SignalRServiceBenchmarkPlugin/SignalRServiceBenchmark.sln
@@ -27,6 +27,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Plugin.Microsoft.Azure.Sign
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "signalr", "signalr", "{4DD87048-C5FB-4916-8AFF-9FF19EEFFEDE}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-signalr-bench", "src\dotnet-signalr-bench\dotnet-signalr-bench.csproj", "{864182CC-E4C3-4B18-9830-A219455F2C3E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -61,6 +63,10 @@ Global
 		{0FE83222-6498-4023-AA76-67D1AC264507}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0FE83222-6498-4023-AA76-67D1AC264507}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0FE83222-6498-4023-AA76-67D1AC264507}.Release|Any CPU.Build.0 = Release|Any CPU
+		{864182CC-E4C3-4B18-9830-A219455F2C3E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{864182CC-E4C3-4B18-9830-A219455F2C3E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{864182CC-E4C3-4B18-9830-A219455F2C3E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{864182CC-E4C3-4B18-9830-A219455F2C3E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -76,6 +82,7 @@ Global
 		{43962F64-1144-4175-AAB3-491C970EF182} = {FDF450A1-0806-4773-94EA-3B39FCEBD21F}
 		{0FE83222-6498-4023-AA76-67D1AC264507} = {4DD87048-C5FB-4916-8AFF-9FF19EEFFEDE}
 		{4DD87048-C5FB-4916-8AFF-9FF19EEFFEDE} = {A595E576-20C8-4980-B1CA-828AD0721C44}
+		{864182CC-E4C3-4B18-9830-A219455F2C3E} = {FDF450A1-0806-4773-94EA-3B39FCEBD21F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {74F85124-663D-4290-9699-7FB524E07A8C}

--- a/SignalRServiceBenchmarkPlugin/build.bat
+++ b/SignalRServiceBenchmarkPlugin/build.bat
@@ -6,8 +6,4 @@ cd src\rpc
 call build.bat
 cd ..\..
 
-cd src\appserver
-call build.bat
-cd ..\..
-
 call korebuild.cmd %*

--- a/SignalRServiceBenchmarkPlugin/build.sh
+++ b/SignalRServiceBenchmarkPlugin/build.sh
@@ -22,4 +22,4 @@ kore_build()
 
 export _PackTool=true
 build
-kore_build
+kore_build "$@"

--- a/SignalRServiceBenchmarkPlugin/build.sh
+++ b/SignalRServiceBenchmarkPlugin/build.sh
@@ -5,9 +5,6 @@ build()
   cd src/rpc
   ./build.sh
   cd ../..
-  cd src/appserver
-  ./build.sh
-  cd ../..
 }
 
 kore_build()

--- a/SignalRServiceBenchmarkPlugin/build/dependencies.props
+++ b/SignalRServiceBenchmarkPlugin/build/dependencies.props
@@ -6,7 +6,7 @@
     <!-- Azure ASP.NET Core SignalR -->
     <MicrosoftAspNetCoreVersion>2.1.0</MicrosoftAspNetCoreVersion>
     <MicrosoftAspNetCoreAppVersion>2.1.7</MicrosoftAspNetCoreAppVersion>
-    <MicrosoftAspNetCoreMvcVersion>2.2.0</MicrosoftAspNetCoreMvcVersion>
+    <MicrosoftAspNetCoreMvcVersion>2.1.3</MicrosoftAspNetCoreMvcVersion>
     <MicrosoftAspNetCoreHttpConnectionsVersion>1.0.4</MicrosoftAspNetCoreHttpConnectionsVersion>
     <MicrosoftAspNetCoreSignalRClientVersion>1.0.4</MicrosoftAspNetCoreSignalRClientVersion>
     <MicrosoftAspNetCoreSignalRProtocolMessagePackPackageVersion>1.0.11</MicrosoftAspNetCoreSignalRProtocolMessagePackPackageVersion>
@@ -14,7 +14,7 @@
     <MicrosoftAspNetSignalRClientVersion>2.4.0</MicrosoftAspNetSignalRClientVersion>
     <MicrosoftAzureSignalRManagementVersion>1.0.0</MicrosoftAzureSignalRManagementVersion>
     <MicrosoftAzureSignalRVersion>1.0.11</MicrosoftAzureSignalRVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>2.2.0</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>2.1.1</MicrosoftExtensionsDependencyInjectionVersion>
     <MicrosoftExtensionsHttpVersion>2.2.0</MicrosoftExtensionsHttpVersion>
     <MicrosoftExtensionsLoggingVersion>2.2.0</MicrosoftExtensionsLoggingVersion>
     <SystemIdentityModelTokensJwtVersion>5.4.0</SystemIdentityModelTokensJwtVersion>

--- a/SignalRServiceBenchmarkPlugin/build/dependencies.props
+++ b/SignalRServiceBenchmarkPlugin/build/dependencies.props
@@ -4,7 +4,8 @@
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
     <!-- Azure ASP.NET Core SignalR -->
-    <MicrosoftAspNetCoreVersion>2.2.0</MicrosoftAspNetCoreVersion>
+    <MicrosoftAspNetCoreVersion>2.1.0</MicrosoftAspNetCoreVersion>
+    <MicrosoftAspNetCoreAppVersion>2.1.7</MicrosoftAspNetCoreAppVersion>
     <MicrosoftAspNetCoreMvcVersion>2.2.0</MicrosoftAspNetCoreMvcVersion>
     <MicrosoftAspNetCoreHttpConnectionsVersion>1.0.4</MicrosoftAspNetCoreHttpConnectionsVersion>
     <MicrosoftAspNetCoreSignalRClientVersion>1.0.4</MicrosoftAspNetCoreSignalRClientVersion>
@@ -29,6 +30,7 @@
     <GrpcToolsVersion>1.15.0</GrpcToolsVersion>
     <GoogleProtobufVersion>3.6.1</GoogleProtobufVersion>
     <GoogleProtobufToolsVersion>3.6.1</GoogleProtobufToolsVersion>
+    <McMasterExtensionsCommandLineUtilsVersion>2.3.4</McMasterExtensionsCommandLineUtilsVersion>
     <MedallionShellVersion>1.5.1</MedallionShellVersion>
     <NewtonsoftJsonVersion>11.0.2</NewtonsoftJsonVersion>
     <SerilogAspNetCoreVersion>2.1.1</SerilogAspNetCoreVersion>

--- a/SignalRServiceBenchmarkPlugin/build/repo.props
+++ b/SignalRServiceBenchmarkPlugin/build/repo.props
@@ -7,15 +7,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <FilesToSign Include="$(RepositoryRoot)src\master\bin\$(Configuration)\**\master.dll" Certificate="$(AssemblySigningCertName)" />
-    <FilesToSign Include="$(RepositoryRoot)src\agent\bin\$(Configuration)\**\agent.dll" Certificate="$(AssemblySigningCertName)" />
+    <FilesToSign Include="$(RepositoryRoot)src\**\bin\$(Configuration)\**\master.dll" Certificate="$(AssemblySigningCertName)" />
+    <FilesToSign Include="$(RepositoryRoot)src\**\bin\$(Configuration)\**\agent.dll" Certificate="$(AssemblySigningCertName)" />
     <FilesToSign Include="$(RepositoryRoot)src\**\bin\$(Configuration)\**\common.dll" Certificate="$(AssemblySigningCertName)" />
     <FilesToSign Include="$(RepositoryRoot)src\**\bin\$(Configuration)\**\interface.dll" Certificate="$(AssemblySigningCertName)" />
     <FilesToSign Include="$(RepositoryRoot)src\**\bin\$(Configuration)\**\rpc.dll" Certificate="$(AssemblySigningCertName)" />
     <FilesToSign Include="$(RepositoryRoot)src\**\bin\$(Configuration)\**\Microsoft.*.dll" Certificate="$(AssemblySigningCertName)" />
     <FilesToSign Include="$(RepositoryRoot)src\**\bin\$(Configuration)\**\System.*.dll" Certificate="$(AssemblySigningCertName)" />
-    <FilesToSign Include="$(RepositoryRoot)src\signalr\bin\$(Configuration)\**\Plugin.Microsoft.Azure.SignalR.Benchmark.dll" Certificate="$(AssemblySigningCertName)" />
-    <FilesToSign Include="$(RepositoryRoot)src\appserver\bin\$(Configuration)\**\appserver.dll" Certificate="$(AssemblySigningCertName)" />
+    <FilesToSign Include="$(RepositoryRoot)src\**\bin\$(Configuration)\**\Plugin.Microsoft.Azure.SignalR.Benchmark.dll" Certificate="$(AssemblySigningCertName)" />
+    <FilesToSign Include="$(RepositoryRoot)src\**\bin\$(Configuration)\**\appserver.dll" Certificate="$(AssemblySigningCertName)" />
+    <FilesToSign Include="$(RepositoryRoot)src\**\bin\$(Configuration)\**\dotnet-signalr-bench.dll" Certificate="$(AssemblySigningCertName)" />
   </ItemGroup>
 
   <ItemGroup Label="Code sign exclusions">
@@ -23,13 +24,14 @@
     <FilesToExcludeFromSigning Include="$(RepositoryRoot)src\**\bin\$(Configuration)\**\CommandLine.dll" />
     <FilesToExcludeFromSigning Include="$(RepositoryRoot)src\**\bin\$(Configuration)\**\Google.Protobuf.dll" />
     <FilesToExcludeFromSigning Include="$(RepositoryRoot)src\**\bin\$(Configuration)\**\Grpc.Core.dll" />
+    <FilesToExcludeFromSigning Include="$(RepositoryRoot)src\**\bin\$(Configuration)\**\grpc_csharp_ext.*.dll" />
     <FilesToExcludeFromSigning Include="$(RepositoryRoot)src\**\bin\$(Configuration)\**\MessagePack.dll" />
     <FilesToExcludeFromSigning Include="$(RepositoryRoot)src\**\bin\$(Configuration)\**\Newtonsoft.Json.Bson.dll" />
     <FilesToExcludeFromSigning Include="$(RepositoryRoot)src\**\bin\$(Configuration)\**\Newtonsoft.Json.dll" />
     <FilesToExcludeFromSigning Include="$(RepositoryRoot)src\**\bin\$(Configuration)\**\Serilog.dll" />
     <FilesToExcludeFromSigning Include="$(RepositoryRoot)src\**\bin\$(Configuration)\**\Serilog.*.dll" />
     <FilesToExcludeFromSigning Include="$(RepositoryRoot)src\**\bin\$(Configuration)\**\YamlDotNet.dll" />
-    <FilesToExcludeFromSigning Include="$(RepositoryRoot)src\**\bin\$(Configuration)\**\grpc_csharp_ext.*.dll" />
+    <FilesToExcludeFromSigning Include="$(RepositoryRoot)src\**\bin\$(Configuration)\**\McMaster.Extensions.CommandLineUtils.dll" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SignalRServiceBenchmarkPlugin/src/agent/Agent.cs
+++ b/SignalRServiceBenchmarkPlugin/src/agent/Agent.cs
@@ -1,0 +1,30 @@
+﻿using Common;
+using Rpc.Service;
+using System.Threading.Tasks;
+
+namespace Rpc.Agent
+{
+    public class Agent
+    {
+        private RpcConfig _rpcConfig;
+
+        public Agent(RpcConfig config)
+        {
+            _rpcConfig = config;
+        }
+
+        public async Task Start()
+        {
+            Util.SavePidToFile(_rpcConfig.PidFile);
+
+            // Create Logger
+            RpcUtils.CreateLogger(_rpcConfig.LogDirectory, _rpcConfig.LogName, _rpcConfig.LogTarget);
+
+            // Create Rpc server
+            var server = new RpcServer().Create(_rpcConfig.HostName, _rpcConfig.RpcPort);
+
+            // Start Rpc server
+            await server.Start();
+        }
+    }
+}

--- a/SignalRServiceBenchmarkPlugin/src/agent/ArgsOption.cs
+++ b/SignalRServiceBenchmarkPlugin/src/agent/ArgsOption.cs
@@ -14,7 +14,7 @@ namespace Rpc.Agent
         public string PidFile { get; set; }
 
         [Option("HostName", Required = false, Default = "localhost", HelpText = "Hostname.")]
-        public string HostName{ get; set; }
+        public string HostName { get; set; }
 
         // Log
         [Option("LogName", Required = false, Default = "agent-.log", HelpText = "Log file name. " +

--- a/SignalRServiceBenchmarkPlugin/src/agent/Program.cs
+++ b/SignalRServiceBenchmarkPlugin/src/agent/Program.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using CommandLine;
-using System.Threading.Tasks;
-using Rpc.Service;
+﻿using CommandLine;
 using Common;
+using Rpc.Service;
 using Serilog;
+using System.Threading.Tasks;
 
 namespace Rpc.Agent
 {
@@ -19,16 +18,33 @@ namespace Rpc.Agent
                 return;
             }
 
-            Util.SavePidToFile(argsOption.PidFile);
+            var config = GenConfig(argsOption);
+            var agent = new Agent(config);
+            await agent.Start();
+        }
 
-            // Create Logger
-            Util.CreateLogger(argsOption.LogDirectory, argsOption.LogName, argsOption.LogTarget);
-
-            // Create Rpc server
-            var server = new RpcServer().Create(argsOption.HostName, argsOption.RpcPort);
-
-            // Start Rpc server
-            await server.Start();
+        private static RpcConfig GenConfig(ArgsOption option)
+        {
+            var logTarget = RpcLogTargetEnum.All;
+            if (option.LogTarget == LogTargetEnum.Console)
+            {
+                logTarget = RpcLogTargetEnum.Console;
+            }
+            else if (option.LogTarget == LogTargetEnum.File)
+            {
+                logTarget = RpcLogTargetEnum.File;
+            }
+            var config = new RpcConfig()
+            {
+                PidFile = option.PidFile,
+                LogTarget = logTarget,
+                LogName = option.LogName,
+                LogDirectory = option.LogDirectory,
+                RpcPort = option.RpcPort,
+                HostName = option.HostName
+            };
+            
+            return config;
         }
 
         private static ArgsOption ParseArgs(string[] args)

--- a/SignalRServiceBenchmarkPlugin/src/agent/agent.csproj
+++ b/SignalRServiceBenchmarkPlugin/src/agent/agent.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\common\common.csproj" />
+    <ProjectReference Include="..\signalr\Plugin.Microsoft.Azure.SignalR.Benchmark.csproj" />
     <ProjectReference Include="..\rpc\rpc.csproj" />
   </ItemGroup>
 

--- a/SignalRServiceBenchmarkPlugin/src/agent/agent.csproj
+++ b/SignalRServiceBenchmarkPlugin/src/agent/agent.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\shared.targets" Condition="'$(_PackTool)' == 'true'"/>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -13,7 +12,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\common\common.csproj" />
-    <ProjectReference Include="..\signalr\Plugin.Microsoft.Azure.SignalR.Benchmark.csproj" />
     <ProjectReference Include="..\rpc\rpc.csproj" />
   </ItemGroup>
 

--- a/SignalRServiceBenchmarkPlugin/src/appserver/AppServerConfig.cs
+++ b/SignalRServiceBenchmarkPlugin/src/appserver/AppServerConfig.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.SignalR.PerfTest.AppServer
+{
+    public class AppServerConfig
+    {
+        // 0 means self-host SignalR, 1 means ASRS. Default is 0.
+        public int SignalRType { get; set; } = 0;
+
+        // in hour
+        public int AccessTokenLifetime { get; set; } = 24;
+
+        public int ConnectionNumber { get; set; } = 5;
+
+        public string ConnectionString { get; set; }
+    }
+}

--- a/SignalRServiceBenchmarkPlugin/src/appserver/Startup.cs
+++ b/SignalRServiceBenchmarkPlugin/src/appserver/Startup.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.SignalR.PerfTest.AppServer
 {
     public class Startup
     {
-        private const string HUB_NAME = "/signalrbench";
+        internal const string HUB_NAME = "/signalrbench";
 
         private AppServerConfig _serverConfig;
         private bool _useLocalSignalR;

--- a/SignalRServiceBenchmarkPlugin/src/appserver/appserver.csproj
+++ b/SignalRServiceBenchmarkPlugin/src/appserver/appserver.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="$(MicrosoftAspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(MicrosoftAspNetCoreMvcVersion)" />
     <PackageReference Include="Microsoft.Azure.SignalR" Version="$(MicrosoftAzureSignalRVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(MicrosoftAspNetCoreStaticFilesVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="$(MicrosoftAspNetCoreSignalRProtocolMessagePackPackageVersion)" />

--- a/SignalRServiceBenchmarkPlugin/src/appserver/appserver.csproj
+++ b/SignalRServiceBenchmarkPlugin/src/appserver/appserver.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <UserSecretsId>appserver</UserSecretsId>
     <LangVersion>latest</LangVersion>
-    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SignalRServiceBenchmarkPlugin/src/appserver/appserver.csproj
+++ b/SignalRServiceBenchmarkPlugin/src/appserver/appserver.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-  <Import Project="..\shared.targets" Condition="'$(_PackTool)' == 'true'"/>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>

--- a/SignalRServiceBenchmarkPlugin/src/common/Util.cs
+++ b/SignalRServiceBenchmarkPlugin/src/common/Util.cs
@@ -48,6 +48,39 @@ namespace Common
 
     public class Util
     {
+        public static void CreateLogger(string directory, string name, LogTargetEnum logTarget)
+        {
+            // remove history logs
+            foreach (string f in Directory.EnumerateFiles(directory, name.Replace(".", "*")))
+            {
+                File.Delete(f);
+            }
+            switch (logTarget)
+            {
+
+                case LogTargetEnum.File:
+                    Log.Logger = new LoggerConfiguration()
+                    .MinimumLevel.Debug()
+                    .WriteTo.File(Path.Combine(directory, name), rollingInterval: RollingInterval.Day)
+                    .CreateLogger();
+                    break;
+                case LogTargetEnum.Console:
+                    Log.Logger = new LoggerConfiguration()
+                    .MinimumLevel.Debug()
+                    .WriteTo.Console()
+                    .CreateLogger();
+                    break;
+                default:
+                case LogTargetEnum.All:
+                    Log.Logger = new LoggerConfiguration()
+                    .MinimumLevel.Debug()
+                    .WriteTo.Console()
+                    .WriteTo.File(Path.Combine(directory, name), rollingInterval: RollingInterval.Day)
+                    .CreateLogger();
+                    break;
+            }
+        }
+
         public static string ReadFile(string path)
         {
             try

--- a/SignalRServiceBenchmarkPlugin/src/common/Util.cs
+++ b/SignalRServiceBenchmarkPlugin/src/common/Util.cs
@@ -48,39 +48,6 @@ namespace Common
 
     public class Util
     {
-        public static void CreateLogger(string directory, string name, LogTargetEnum logTarget)
-        {
-            // remove history logs
-            foreach (string f in Directory.EnumerateFiles(directory, name.Replace(".", "*")))
-            {
-                File.Delete(f);
-            }
-            switch (logTarget)
-            {
-                
-                case LogTargetEnum.File:
-                    Log.Logger = new LoggerConfiguration()
-                    .MinimumLevel.Debug()
-                    .WriteTo.File(Path.Combine(directory, name), rollingInterval: RollingInterval.Day)
-                    .CreateLogger();
-                    break;
-                case LogTargetEnum.Console:
-                    Log.Logger = new LoggerConfiguration()
-                    .MinimumLevel.Debug()
-                    .WriteTo.Console()
-                    .CreateLogger();
-                    break;
-                default:
-                case LogTargetEnum.All:
-                    Log.Logger = new LoggerConfiguration()
-                    .MinimumLevel.Debug()
-                    .WriteTo.Console()
-                    .WriteTo.File(Path.Combine(directory, name), rollingInterval: RollingInterval.Day)
-                    .CreateLogger();
-                    break;
-            }
-        }
-
         public static string ReadFile(string path)
         {
             try

--- a/SignalRServiceBenchmarkPlugin/src/dotnet-signalr-bench/CommandLineOptions.cs
+++ b/SignalRServiceBenchmarkPlugin/src/dotnet-signalr-bench/CommandLineOptions.cs
@@ -1,0 +1,99 @@
+﻿using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+namespace Microsoft.Azure.SignalR.PerfTest.AppServer
+{
+    [Command(
+        Name = "dotnet signalr-bench",
+        FullName = "dotnet-signalr-bench",
+        Description = "SignalR benchmark tool")]
+    [VersionOptionFromMember(MemberName = nameof(GetVersion))]
+    [HelpOption("--help")]
+    [Subcommand(
+        typeof(AgentCommandOptions),
+        typeof(ApplicationCommandOptions),
+        typeof(ControllerCommandOptions))]
+    public class CommandLineOptions
+    {
+        public string GetVersion()
+            => typeof(CommandLineOptions).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+    }
+
+    [Command(Description = "Agent command options")]
+    public class AgentCommandOptions
+    {
+        [Option("-p|--port", Description = "Port to use [7000]. Default is 7000")]
+        public int Port { get; } = 7000;
+
+        [Option("--host", Description = "IP to bind. Default is localhost")]
+        public string HostName { get; } = "localhost";
+    }
+
+    [Command(Description = "Controller command options")]
+    public class ControllerCommandOptions
+    {
+        [Option("-a|--agentlist", Description = "Specify the agents endpoint list with ',' as separator. Default is 'localhost:7000'")]
+        public IList<string> AgentList { get; } = new[] { "localhost:7000" };
+
+        [Option("-c|--configuration", Description = "Sepcify the configuration filename. If it is '?', it will print help for how to create the configuration YAML file.")]
+        public string PluginConfiguration { get; set; }
+    }
+
+    [Command(Description = "Application command options")]
+    public class ApplicationCommandOptions
+    {
+        private LogLevel? _logLevel;
+
+        [Option(Description = "Port to use [5050]. Use 0 for a dynamic port.")]
+        [Range(1024, 65535, ErrorMessage = "Invalid port. Ports must be in the range of 1024 to 65535.")]
+        public int Port { get; } = 5050;
+
+        [Option(Description = "Show less console output.")]
+        public bool Quiet { get; }
+
+        [Option("-t|--signalr-type", Description = "SignalR type: 0 or 1. 0 for local selfhost SignalR, 1 for Azure SignalR Service, default it is 0")]
+        [Range(0, 1, ErrorMessage = "Invalid SignalR type. it must be 0 or 1 for local selfhost SignalR or SignalR Service respectively")]
+        public int SignalRType { get; } = 0;
+
+        [Option("-c|--server-connection", Description = "Set the server connection count to ASRS, default is 5")]
+        [Range(0, 1024, ErrorMessage = "Current valid connection count is 0 ~ 1024")]
+        public int ServerConnectionNumber { get; } = 5;
+
+        [Option("--connection-string", Description = "ASRS connection string")]
+        public string ConnectionString { get; }
+
+        [Option("-l|--access-token-lifetime", Description = "Access token's life time with minimum unit is hour, default is 24 hours")]
+        public int AccessTokenLifetime { get; } = 24;
+
+        [Option(Description = "Show more console output.")]
+        public bool Verbose { get; }
+
+        [Option("--log <LEVEL>", Description = "For advanced diagnostics.", ShowInHelpText = false)]
+        public LogLevel MinLogLevel
+        {
+            get
+            {
+                if (_logLevel.HasValue)
+                {
+                    return _logLevel.Value;
+                }
+
+                if (Quiet)
+                {
+                    return LogLevel.Error;
+                }
+
+                if (Verbose)
+                {
+                    return LogLevel.Debug;
+                }
+
+                return LogLevel.Information;
+            }
+            private set => _logLevel = value;
+        }
+    }
+}

--- a/SignalRServiceBenchmarkPlugin/src/dotnet-signalr-bench/Program.cs
+++ b/SignalRServiceBenchmarkPlugin/src/dotnet-signalr-bench/Program.cs
@@ -1,0 +1,113 @@
+﻿using McMaster.Extensions.CommandLineUtils;
+using Rpc.Service;
+using System;
+
+namespace Microsoft.Azure.SignalR.PerfTest.AppServer
+{
+    class Program
+    {
+        private const int ERROR = 2;
+        private const int OK = 0;
+
+        static int Main(string[] args)
+        {
+            try
+            {
+                var app = new CommandLineApplication<CommandLineOptions>();
+                app.Command<AgentCommandOptions>("agent", cmd =>
+                {
+                    cmd.OnExecute(async () =>
+                    {
+                        try
+                        {
+                            var config = GenAgentConfig(cmd.Model);
+                            var agent = new Rpc.Agent.Agent(config);
+                            await agent.Start();
+                        }
+                        catch (Exception ex)
+                        {
+                            ReportError(ex);
+                        }
+                    });
+                });
+                app.Command<ControllerCommandOptions>("controller", cmd =>
+                {
+                    cmd.OnExecute(async () =>
+                    {
+                        var config = GenControllerConfig(cmd.Model);
+                        var controller = new Rpc.Master.Controller(config);
+                        await controller.Start();
+                    });
+                });
+                app.Command<ApplicationCommandOptions>("application", cmd =>
+                {
+                    cmd.OnExecute(async () =>
+                    {
+                        try
+                        {
+                            var server = new AppServer(cmd.Model, PhysicalConsole.Singleton);
+                            await server.RunAsync();
+                        }
+                        catch (Exception ex)
+                        {
+                            ReportError(ex);
+                        }
+                    });
+                });
+                app.Conventions.UseDefaultConventions();
+                app.OnExecute(() =>
+                {
+                    Console.WriteLine("Specify a subcommand");
+                    app.ShowHelp();
+                    return 1;
+                });
+                return app.Execute(args);
+            }
+            catch (Exception ex)
+            {
+                ReportError(ex);
+                return ERROR;
+            }
+        }
+
+        private static void ReportError(Exception ex)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.Error.WriteLine($"Unexpected error: {ex}");
+            Console.ResetColor();
+        }
+
+        private static RpcConfig GenAgentConfig(AgentCommandOptions option)
+        {
+            var logTarget = RpcLogTargetEnum.All;
+            var config = new RpcConfig()
+            {
+                PidFile = "agent-pid.txt",
+                LogTarget = logTarget,
+                LogName = "agent-.log",
+                LogDirectory = ".",
+                RpcPort = option.Port,
+                HostName = option.HostName
+            };
+            return config;
+        }
+
+        private static RpcConfig GenControllerConfig(ControllerCommandOptions option)
+        {
+            var logTarget = RpcLogTargetEnum.All;
+            
+            var config = new RpcConfig()
+            {
+                PidFile = "master-pid.txt",
+                LogTarget = logTarget,
+                LogName = "master-.log",
+                LogDirectory = ".",
+                AgentList = option.AgentList,
+                PluginFullName = "Plugin.Microsoft.Azure.SignalR.Benchmark.SignalRBenchmarkPlugin, Plugin.Microsoft.Azure.SignalR.Benchmark",
+                PluginConfiguration = option.PluginConfiguration
+            };
+
+            return config;
+        }
+    }
+}

--- a/SignalRServiceBenchmarkPlugin/src/dotnet-signalr-bench/Program.cs
+++ b/SignalRServiceBenchmarkPlugin/src/dotnet-signalr-bench/Program.cs
@@ -1,113 +1,12 @@
 ﻿using McMaster.Extensions.CommandLineUtils;
-using Rpc.Service;
-using System;
 
 namespace Microsoft.Azure.SignalR.PerfTest.AppServer
 {
     class Program
     {
-        private const int ERROR = 2;
-        private const int OK = 0;
-
         static int Main(string[] args)
         {
-            try
-            {
-                var app = new CommandLineApplication<CommandLineOptions>();
-                app.Command<AgentCommandOptions>("agent", cmd =>
-                {
-                    cmd.OnExecute(async () =>
-                    {
-                        try
-                        {
-                            var config = GenAgentConfig(cmd.Model);
-                            var agent = new Rpc.Agent.Agent(config);
-                            await agent.Start();
-                        }
-                        catch (Exception ex)
-                        {
-                            ReportError(ex);
-                        }
-                    });
-                });
-                app.Command<ControllerCommandOptions>("controller", cmd =>
-                {
-                    cmd.OnExecute(async () =>
-                    {
-                        var config = GenControllerConfig(cmd.Model);
-                        var controller = new Rpc.Master.Controller(config);
-                        await controller.Start();
-                    });
-                });
-                app.Command<ApplicationCommandOptions>("application", cmd =>
-                {
-                    cmd.OnExecute(async () =>
-                    {
-                        try
-                        {
-                            var server = new AppServer(cmd.Model, PhysicalConsole.Singleton);
-                            await server.RunAsync();
-                        }
-                        catch (Exception ex)
-                        {
-                            ReportError(ex);
-                        }
-                    });
-                });
-                app.Conventions.UseDefaultConventions();
-                app.OnExecute(() =>
-                {
-                    Console.WriteLine("Specify a subcommand");
-                    app.ShowHelp();
-                    return 1;
-                });
-                return app.Execute(args);
-            }
-            catch (Exception ex)
-            {
-                ReportError(ex);
-                return ERROR;
-            }
-        }
-
-        private static void ReportError(Exception ex)
-        {
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.Error.WriteLine($"Unexpected error: {ex}");
-            Console.ResetColor();
-        }
-
-        private static RpcConfig GenAgentConfig(AgentCommandOptions option)
-        {
-            var logTarget = RpcLogTargetEnum.All;
-            var config = new RpcConfig()
-            {
-                PidFile = "agent-pid.txt",
-                LogTarget = logTarget,
-                LogName = "agent-.log",
-                LogDirectory = ".",
-                RpcPort = option.Port,
-                HostName = option.HostName
-            };
-            return config;
-        }
-
-        private static RpcConfig GenControllerConfig(ControllerCommandOptions option)
-        {
-            var logTarget = RpcLogTargetEnum.All;
-            
-            var config = new RpcConfig()
-            {
-                PidFile = "master-pid.txt",
-                LogTarget = logTarget,
-                LogName = "master-.log",
-                LogDirectory = ".",
-                AgentList = option.AgentList,
-                PluginFullName = "Plugin.Microsoft.Azure.SignalR.Benchmark.SignalRBenchmarkPlugin, Plugin.Microsoft.Azure.SignalR.Benchmark",
-                PluginConfiguration = option.PluginConfiguration
-            };
-
-            return config;
+            return CommandLineApplication.Execute<CommandLineOptions>(args);
         }
     }
 }

--- a/SignalRServiceBenchmarkPlugin/src/dotnet-signalr-bench/application/AppServer.cs
+++ b/SignalRServiceBenchmarkPlugin/src/dotnet-signalr-bench/application/AppServer.cs
@@ -1,0 +1,73 @@
+﻿using McMaster.Extensions.CommandLineUtils;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.SignalR.PerfTest.AppServer
+{
+    public class AppServer
+    {
+        private readonly ApplicationCommandOptions _options;
+        private readonly IConsole _console;
+        private readonly IReporter _reporter;
+        
+        public AppServer(ApplicationCommandOptions options, IConsole console)
+        {
+            _options = options;
+            _console = console;
+            _reporter = new ConsoleReporter(console)
+            {
+                IsQuiet = options.Quiet,
+                IsVerbose = options.Verbose,
+            };
+            ValidateCommandLineOptions(options, _reporter);
+        }
+
+        public async Task<int> RunAsync()
+        {
+            var cts = new CancellationTokenSource();
+            var port = _options.Port;
+
+            _console.CancelKeyPress += (o, e) =>
+            {
+                _console.WriteLine("Shutting down...");
+                cts.Cancel();
+            };
+            
+            var host = new WebHostBuilder()
+                .ConfigureLogging(l =>
+                {
+                    l.SetMinimumLevel(_options.MinLogLevel);
+                    l.AddConsole();
+                })
+                .PreferHostingUrls(false)
+                .UseKestrel(o =>
+                {
+                    o.ListenAnyIP(port);
+                })
+                .UseEnvironment("Production")
+                .UseStartup<Startup>()
+                .ConfigureServices(s => s.AddSingleton(_options))
+                .Build();
+
+            _console.Write("Starting server");
+            await host.StartAsync(cts.Token);
+            await host.WaitForShutdownAsync(cts.Token);
+            return 0;
+        }
+
+        private void ValidateCommandLineOptions(ApplicationCommandOptions options, IReporter reporter)
+        {
+            if (options.SignalRType == 1 && string.IsNullOrEmpty(options.ConnectionString))
+            {
+                var err = "Use ASRS but forget to set connection string!";
+                reporter.Error(err);
+                throw new InvalidOperationException(err);
+            }
+        }
+
+    }
+}

--- a/SignalRServiceBenchmarkPlugin/src/dotnet-signalr-bench/dotnet-signalr-bench.csproj
+++ b/SignalRServiceBenchmarkPlugin/src/dotnet-signalr-bench/dotnet-signalr-bench.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="$(MicrosoftAspNetCoreAppVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="$(MicrosoftAspNetCoreSignalRClientVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="$(MicrosoftAspNetCoreSignalRProtocolMessagePackPackageVersion)" />
     <PackageReference Include="Microsoft.Azure.SignalR" Version="$(MicrosoftAzureSignalRVersion)" />
@@ -16,11 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\appserver\AppServerConfig.cs" Link="application\AppServerConfig.cs" />
-    <Compile Include="..\appserver\Hub\BenchHub.cs" Link="application\Hub\BenchHub.cs" />
-    <Compile Include="..\appserver\Startup.cs" Link="application\Startup.cs" />
-    <Compile Include="..\appserver\TimedLogger.cs" Link="application\TimedLogger.cs" />
-    <Compile Include="..\appserver\TimedLoggerFactory.cs" Link="application\TimedLoggerFactory.cs" />
     <Compile Include="..\agent\Agent.cs" Link="agent\Agent.cs" />
     <Compile Include="..\master\Controller.cs" Link="controller\Controller.cs" />
   </ItemGroup>
@@ -28,5 +23,6 @@
   <ItemGroup>
     <ProjectReference Include="..\common\common.csproj" />
     <ProjectReference Include="..\rpc\rpc.csproj" />
+    <ProjectReference Include="..\signalr\Plugin.Microsoft.Azure.SignalR.Benchmark.csproj" /> <!-- we need to pack this project to target package -->
   </ItemGroup>
 </Project>

--- a/SignalRServiceBenchmarkPlugin/src/dotnet-signalr-bench/dotnet-signalr-bench.csproj
+++ b/SignalRServiceBenchmarkPlugin/src/dotnet-signalr-bench/dotnet-signalr-bench.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\shared.targets" Condition="'$(_PackTool)' == 'true'" />
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <IsPackable>true</IsPackable>
+    <AssemblyName>dotnet-signalr-bench</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="$(MicrosoftAspNetCoreAppVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="$(MicrosoftAspNetCoreSignalRClientVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="$(MicrosoftAspNetCoreSignalRProtocolMessagePackPackageVersion)" />
+    <PackageReference Include="Microsoft.Azure.SignalR" Version="$(MicrosoftAzureSignalRVersion)" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="$(McMasterExtensionsCommandLineUtilsVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\appserver\AppServerConfig.cs" Link="application\AppServerConfig.cs" />
+    <Compile Include="..\appserver\Hub\BenchHub.cs" Link="application\Hub\BenchHub.cs" />
+    <Compile Include="..\appserver\Startup.cs" Link="application\Startup.cs" />
+    <Compile Include="..\appserver\TimedLogger.cs" Link="application\TimedLogger.cs" />
+    <Compile Include="..\appserver\TimedLoggerFactory.cs" Link="application\TimedLoggerFactory.cs" />
+    <Compile Include="..\agent\Agent.cs" Link="agent\Agent.cs" />
+    <Compile Include="..\master\Controller.cs" Link="controller\Controller.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\common\common.csproj" />
+    <ProjectReference Include="..\rpc\rpc.csproj" />
+  </ItemGroup>
+</Project>

--- a/SignalRServiceBenchmarkPlugin/src/master/Controller.cs
+++ b/SignalRServiceBenchmarkPlugin/src/master/Controller.cs
@@ -1,0 +1,116 @@
+﻿using Common;
+using Grpc.Core;
+using Grpc.Core.Logging;
+using Plugin.Base;
+using Rpc.Service;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Rpc.Master
+{
+    public class Controller
+    {
+        private static readonly int _maxRertryConnect = 100;
+        private static TimeSpan _retryInterval = TimeSpan.FromSeconds(1);
+        private RpcConfig _rpcConfig;
+
+        public Controller(RpcConfig config)
+        {
+            _rpcConfig = config;
+        }
+
+        public async Task Start()
+        {
+            Util.SavePidToFile(_rpcConfig.PidFile);
+
+            // Create Logger
+            RpcUtils.CreateLogger(_rpcConfig.LogDirectory, _rpcConfig.LogName, _rpcConfig.LogTarget);
+
+            var type = Type.GetType(_rpcConfig.PluginFullName);
+
+            var plugin = (IPlugin)Activator.CreateInstance(type);
+
+            if (!CheckUsage(_rpcConfig, plugin))
+            {
+                // Load benchmark configuration
+                var configuration = Util.ReadFile(_rpcConfig.PluginConfiguration);
+                IList<IRpcClient> clients = null;
+                if (plugin.NeedAgents(configuration))
+                {
+                    // Create rpc clients
+                    clients = CreateRpcClients(_rpcConfig.AgentList);
+
+                    // Check rpc connections
+                    await WaitRpcConnectSuccess(clients);
+                }
+
+                await plugin.Start(configuration, clients);
+            }
+        }
+
+        private static bool CheckUsage(RpcConfig argsOption, IPlugin plugin)
+        {
+            if (argsOption.PluginConfiguration == "?")
+            {
+                plugin.Help();
+                return true;
+            }
+            return false;
+        }
+
+        private static void EnableTracing()
+        {
+            Environment.SetEnvironmentVariable("GRPC_TRACE", "tcp,channel,http,secure_endpoint");
+            Environment.SetEnvironmentVariable("GRPC_VERBOSITY", "DEBUG");
+            GrpcEnvironment.SetLogger(new ConsoleLogger());
+        }
+
+        private static IList<IRpcClient> CreateRpcClients(IList<string> agentList)
+        {
+            var hostnamePortList = (from agent in agentList
+                                    select agent.Split(':') into parts
+                                    select (Hostname: parts[0], Port: Convert.ToInt32(parts[1])));
+
+            var clients = from item in hostnamePortList
+                          select RpcClient.Create(item.Hostname, item.Port);
+
+            return clients.ToList();
+        }
+
+        private static async Task WaitRpcConnectSuccess(IList<IRpcClient> clients)
+        {
+            Log.Information("Connect Rpc agents...");
+            for (var i = 0; i < _maxRertryConnect; i++)
+            {
+                try
+                {
+                    foreach (var client in clients)
+                    {
+                        try
+                        {
+                            client.TestConnection();
+                        }
+                        catch (Exception)
+                        {
+                            throw;
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning($"Fail to connect agents because of {ex.Message}, retry {i}th time");
+                    await Task.Delay(_retryInterval);
+                    continue;
+                }
+                return;
+            }
+
+            var message = $"Cannot connect to all agents.";
+            Log.Error(message);
+            throw new Exception(message);
+        }
+    }
+}

--- a/SignalRServiceBenchmarkPlugin/src/master/master.csproj
+++ b/SignalRServiceBenchmarkPlugin/src/master/master.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <ProjectReference Include="..\common\common.csproj" />
     <ProjectReference Include="..\interface\interface.csproj" />
+    <ProjectReference Include="..\signalr\Plugin.Microsoft.Azure.SignalR.Benchmark.csproj" />
     <ProjectReference Include="..\rpc\rpc.csproj" />
   </ItemGroup>
 

--- a/SignalRServiceBenchmarkPlugin/src/master/master.csproj
+++ b/SignalRServiceBenchmarkPlugin/src/master/master.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\shared.targets" Condition="'$(_PackTool)' == 'true'"/>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -18,7 +17,6 @@
   <ItemGroup>
     <ProjectReference Include="..\common\common.csproj" />
     <ProjectReference Include="..\interface\interface.csproj" />
-    <ProjectReference Include="..\signalr\Plugin.Microsoft.Azure.SignalR.Benchmark.csproj" />
     <ProjectReference Include="..\rpc\rpc.csproj" />
   </ItemGroup>
 

--- a/SignalRServiceBenchmarkPlugin/src/rpc/RpcConfig.cs
+++ b/SignalRServiceBenchmarkPlugin/src/rpc/RpcConfig.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+
+namespace Rpc.Service
+{
+    public enum RpcLogTargetEnum
+    {
+        File,
+        Console,
+        All
+    }
+
+    public class RpcConfig
+    {
+        #region common configuration
+        /// <summary>
+        /// File name for pid
+        /// </summary>
+        public string PidFile { get; set; }
+
+        /// <summary>
+        /// Set the log target: file/console/all
+        /// </summary>
+        public RpcLogTargetEnum LogTarget { get; set; } = RpcLogTargetEnum.All;
+
+        /// <summary>
+        /// Set the log file name prefix
+        /// </summary>
+        public string LogName { get; set; }
+
+        /// <summary>
+        /// Set the log directory
+        /// </summary>
+        public string LogDirectory { get; set; } = ".";
+
+        #endregion
+
+        #region agent configuration
+        /// <summary>
+        /// Agent listening port
+        /// </summary>
+        public int RpcPort { get; set; } = 7000;
+
+        /// <summary>
+        /// Agent binding address
+        /// </summary>
+        public string HostName { get; set; } = "localhost";
+        #endregion
+
+        #region master configuration
+        /// <summary>
+        /// IP:Port list of agent nodes
+        /// </summary>
+        public IList<string> AgentList { get; set; }
+
+        /// <summary>
+        /// Set the plugin full name
+        /// </summary>
+        public string PluginFullName { get; set; }
+
+        /// <summary>
+        /// Set the plugin configuration file. If it is '?', the plugin will print help usage
+        /// </summary>
+        public string PluginConfiguration { get; set; }
+        #endregion
+    }
+}

--- a/SignalRServiceBenchmarkPlugin/src/rpc/RpcUtils.cs
+++ b/SignalRServiceBenchmarkPlugin/src/rpc/RpcUtils.cs
@@ -5,6 +5,7 @@ namespace Rpc.Service
 {
     public class RpcUtils
     {
+        // This function is copied from common.Util, because we want to use customized LogTargetEnum
         public static void CreateLogger(string directory, string name, RpcLogTargetEnum logTarget)
         {
             // remove history logs

--- a/SignalRServiceBenchmarkPlugin/src/rpc/RpcUtils.cs
+++ b/SignalRServiceBenchmarkPlugin/src/rpc/RpcUtils.cs
@@ -1,0 +1,41 @@
+﻿using Serilog;
+using System.IO;
+
+namespace Rpc.Service
+{
+    public class RpcUtils
+    {
+        public static void CreateLogger(string directory, string name, RpcLogTargetEnum logTarget)
+        {
+            // remove history logs
+            foreach (string f in Directory.EnumerateFiles(directory, name.Replace(".", "*")))
+            {
+                File.Delete(f);
+            }
+            switch (logTarget)
+            {
+
+                case RpcLogTargetEnum.File:
+                    Log.Logger = new LoggerConfiguration()
+                    .MinimumLevel.Debug()
+                    .WriteTo.File(Path.Combine(directory, name), rollingInterval: RollingInterval.Day)
+                    .CreateLogger();
+                    break;
+                case RpcLogTargetEnum.Console:
+                    Log.Logger = new LoggerConfiguration()
+                    .MinimumLevel.Debug()
+                    .WriteTo.Console()
+                    .CreateLogger();
+                    break;
+                default:
+                case RpcLogTargetEnum.All:
+                    Log.Logger = new LoggerConfiguration()
+                    .MinimumLevel.Debug()
+                    .WriteTo.Console()
+                    .WriteTo.File(Path.Combine(directory, name), rollingInterval: RollingInterval.Day)
+                    .CreateLogger();
+                    break;
+            }
+        }
+    }
+}

--- a/SignalRServiceBenchmarkPlugin/src/rpc/rpc.csproj
+++ b/SignalRServiceBenchmarkPlugin/src/rpc/rpc.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
+    <RootNamespace>Rpc.Service</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/SignalRServiceBenchmarkPlugin/src/signalr/Plugin.Microsoft.Azure.SignalR.Benchmark.csproj
+++ b/SignalRServiceBenchmarkPlugin/src/signalr/Plugin.Microsoft.Azure.SignalR.Benchmark.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
-    <!--<ServerGarbageCollection>true</ServerGarbageCollection>-->
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -37,8 +36,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\appserver\Startup.cs" Link="Internals\AppServer\Startup.cs" />
+    <Compile Include="..\appserver\AppServerConfig.cs" Link="Internals\AppServer\AppServerConfig.cs" />
     <Compile Include="..\appserver\Hub\BenchHub.cs" Link="Internals\AppServer\BenchHub.cs" />
+    <Compile Include="..\appserver\Startup.cs" Link="Internals\AppServer\Startup.cs" />
     <Compile Include="..\appserver\TimedLogger.cs" Link="Internals\AppServer\TimedLogger.cs" />
     <Compile Include="..\appserver\TimedLoggerFactory.cs" Link="Internals\AppServer\TimedLoggerFactory.cs" />
   </ItemGroup>

--- a/SignalRServiceBenchmarkPlugin/src/signalr/Plugin.Microsoft.Azure.SignalR.Benchmark.csproj
+++ b/SignalRServiceBenchmarkPlugin/src/signalr/Plugin.Microsoft.Azure.SignalR.Benchmark.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="$(MicrosoftAspNetCoreSignalRClientVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="$(MicrosoftAspNetCoreSignalRProtocolMessagePackPackageVersion)" />
     <PackageReference Include="Microsoft.AspNet.SignalR.Client" Version="$(MicrosoftAspNetSignalRClientVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(MicrosoftAspNetCoreStaticFilesVersion)" />
+    <!--<PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(MicrosoftAspNetCoreStaticFilesVersion)" />-->
     <PackageReference Include="Microsoft.Azure.SignalR.Management" Version="$(MicrosoftAzureSignalRManagementVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsHttpVersion)" />

--- a/SignalRServiceBenchmarkPlugin/test/signalr/Fixture/RpcServerFixture.cs
+++ b/SignalRServiceBenchmarkPlugin/test/signalr/Fixture/RpcServerFixture.cs
@@ -1,12 +1,8 @@
-﻿using Newtonsoft.Json;
-using Plugin.Base;
-using Plugin.Microsoft.Azure.SignalR.Benchmark.Internals;
+﻿using Plugin.Base;
 using Rpc.Service;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit.Abstractions;
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,34 @@
+# ASP.NET Core (.NET Framework)
+# Build and test ASP.NET Core projects targeting the full .NET Framework.
+# Add steps that publish symbols, save build artifacts, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
+
+trigger:
+- master
+
+pool:
+  vmImage: 'windows-latest'
+
+variables:
+  solution: '**/*.sln'
+  buildPlatform: 'Any CPU'
+  buildConfiguration: 'Release'
+
+steps:
+- task: NuGetToolInstaller@1
+
+- task: NuGetCommand@2
+  inputs:
+    restoreSolution: '$(solution)'
+
+- task: VSBuild@1
+  inputs:
+    solution: '$(solution)'
+    msbuildArgs: '/p:DeployOnBuild=true /p:WebPublishMethod=Package /p:PackageAsSingleFile=true /p:SkipInvalidConfigurations=true /p:DesktopBuildPackageLocation="$(build.artifactStagingDirectory)\WebApp.zip" /p:DeployIisAppPath="Default Web Site"'
+    platform: '$(buildPlatform)'
+    configuration: '$(buildConfiguration)'
+
+- task: VSTest@2
+  inputs:
+    platform: '$(buildPlatform)'
+    configuration: '$(buildConfiguration)'


### PR DESCRIPTION
Fix #35 issue
The single global tool 'dotnet-signalr-bench' allows run subcommand to start agent, application, and controller. The parameters are also simplified.