### PR TITLE
Make dotnet-signalr-bench parameters more friendly

### DIFF
--- a/SignalRServiceBenchmarkPlugin/src/appserver/AppServerConfig.cs
+++ b/SignalRServiceBenchmarkPlugin/src/appserver/AppServerConfig.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -16,5 +17,7 @@ namespace Microsoft.Azure.SignalR.PerfTest.AppServer
         public int ConnectionNumber { get; set; } = 5;
 
         public string ConnectionString { get; set; }
+
+        public LogLevel MinLogLevel { get; set; } = LogLevel.Information;
     }
 }

--- a/SignalRServiceBenchmarkPlugin/src/appserver/TimedLoggerFactory.cs
+++ b/SignalRServiceBenchmarkPlugin/src/appserver/TimedLoggerFactory.cs
@@ -8,15 +8,18 @@ namespace Microsoft.Azure.SignalR.PerfTest.AppServer
     {
         private ILoggerFactory _loggerFactory;
         private volatile bool _disposed;
+        private AppServerConfig _appServerConfig;
 
         protected virtual bool CheckDisposed() => _disposed;
 
-        public TimedLoggerFactory()
+        public TimedLoggerFactory(AppServerConfig serverConfig)
         {
+            _appServerConfig = serverConfig;
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddLogging(config =>
             {
                 config.AddConsole();
+                config.SetMinimumLevel(serverConfig.MinLogLevel);
             });
             var serviceProvider = serviceCollection.BuildServiceProvider();
             _loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();

--- a/SignalRServiceBenchmarkPlugin/src/dotnet-signalr-bench/Program.cs
+++ b/SignalRServiceBenchmarkPlugin/src/dotnet-signalr-bench/Program.cs
@@ -1,12 +1,13 @@
 ﻿using McMaster.Extensions.CommandLineUtils;
+using System.Threading.Tasks;
 
 namespace Microsoft.Azure.SignalR.PerfTest.AppServer
 {
     class Program
     {
-        static int Main(string[] args)
+        static async Task Main(string[] args)
         {
-            return CommandLineApplication.Execute<CommandLineOptions>(args);
+            await CommandLineApplication.ExecuteAsync<CommandLineOptions>(args);
         }
     }
 }

--- a/SignalRServiceBenchmarkPlugin/src/dotnet-signalr-bench/application/AppServer.cs
+++ b/SignalRServiceBenchmarkPlugin/src/dotnet-signalr-bench/application/AppServer.cs
@@ -78,7 +78,8 @@ namespace Microsoft.Azure.SignalR.PerfTest.AppServer
                 SignalRType = option.SignalRType,
                 AccessTokenLifetime = option.AccessTokenLifetime,
                 ConnectionNumber = option.ServerConnectionNumber,
-                ConnectionString = option.ConnectionString
+                ConnectionString = option.ConnectionString,
+                MinLogLevel = option.MinLogLevel
             };
             return config;
         }

--- a/SignalRServiceBenchmarkPlugin/src/signalr/Configuration/BenchmarkConfiguration.cs
+++ b/SignalRServiceBenchmarkPlugin/src/signalr/Configuration/BenchmarkConfiguration.cs
@@ -175,16 +175,16 @@ namespace Plugin.Microsoft.Azure.SignalR.Benchmark
             // create statistics
             if (configData.isPerf())
             {
-                var masterStep = InitStatisticsCollector(configData.Scenario.Name);
-                AddSingleMasterStep(masterStep);
-                masterStep = CollectStatistics(configData.Scenario.Name, configData.IsDebug(), configData.Config.ResultFilePath);
-                AddSingleMasterStep(masterStep);
-            }
-            else if (configData.isLongrun())
-            {
                 var masterStep = InitConnectionStatisticsCollector(configData.Scenario.Name);
                 AddSingleMasterStep(masterStep);
                 masterStep = CollectConnectionStatistics(configData.Scenario.Name, configData.IsDebug(), configData.Config.ResultFilePath);
+                AddSingleMasterStep(masterStep);
+            }
+            else if (configData.isStrictPerf())
+            {
+                var masterStep = InitStatisticsCollector(configData.Scenario.Name);
+                AddSingleMasterStep(masterStep);
+                masterStep = CollectStatistics(configData.Scenario.Name, configData.IsDebug(), configData.Config.ResultFilePath);
                 AddSingleMasterStep(masterStep);
             }
             else
@@ -196,12 +196,12 @@ namespace Plugin.Microsoft.Azure.SignalR.Benchmark
             {
                 var masterStep = RegisterRecordLatency(configData.Scenario.Name);
                 AddSingleMasterStep(masterStep);
+                masterStep = RegisterOnConnected(configData.Scenario.Name);
+                AddSingleMasterStep(masterStep);
             }
-            else if (configData.isLongrun())
+            else if (configData.isStrictPerf())
             {
                 var masterStep = RegisterRecordLatency(configData.Scenario.Name);
-                AddSingleMasterStep(masterStep);
-                masterStep = RegisterOnConnected(configData.Scenario.Name);
                 AddSingleMasterStep(masterStep);
             }
             // start connection
@@ -241,7 +241,7 @@ namespace Plugin.Microsoft.Azure.SignalR.Benchmark
                 AddSingleMasterStep(CollectConnectionId(configData.Scenario.Name));
             }
             // setup backgroud task of repairing connections for longrun
-            if (configData.isLongrun())
+            if (configData.isPerf())
             {
                 if (configData.Scenario.Name.EndsWith("Group"))
                 {
@@ -274,7 +274,7 @@ namespace Plugin.Microsoft.Azure.SignalR.Benchmark
                     if (i > 0)
                     {
                         // conditional stop and reconnect
-                        if (configData.isPerf())
+                        if (configData.isStrictPerf())
                         {
                             AddSingleMasterStep(ConditionalStop(configData.Scenario.Name,
                                                                 configData.Config.Connections,

--- a/SignalRServiceBenchmarkPlugin/src/signalr/Configuration/SimpleBenchmarkConfiguration.cs
+++ b/SignalRServiceBenchmarkPlugin/src/signalr/Configuration/SimpleBenchmarkConfiguration.cs
@@ -8,7 +8,7 @@ namespace Plugin.Microsoft.Azure.SignalR.Benchmark
     public enum ConfigurationMode
     {
         simple,
-        advance
+        advanced
     }
 
     public class SimpleBenchmarkConfiguration

--- a/SignalRServiceBenchmarkPlugin/src/signalr/Configuration/SimpleBenchmarkModel.cs
+++ b/SignalRServiceBenchmarkPlugin/src/signalr/Configuration/SimpleBenchmarkModel.cs
@@ -19,10 +19,10 @@ namespace Plugin.Microsoft.Azure.SignalR.Benchmark
         public const double DEFAULT_CONNECT_FAIL_PERCENTAGE = 0.01;
         public const double DEFAULT_MESSAGE_LATENCY_PERCENTAGE = 0.01;
         public const string DEFAULT_KIND = "perf";
-        public const string LONGRUN_KIND = "longrun";
+        public const string STRICTPERF_KIND = "perf2";
         public const string PARSERESULT_KIND = "resultparser";
         public const string DEFAULT_MODE = "simple";
-        public const string ADVANCE_MODE = "advance";
+        public const string ADVANCED_MODE = "advanced";
         public const string DEFAULT_TRANSPORT = "Websockets";
         public const string SSE_TRANSPORT = "ServerSentEvents";
         public const string LONGPOLLING_TRANSPORT = "LongPolling";
@@ -35,6 +35,7 @@ namespace Plugin.Microsoft.Azure.SignalR.Benchmark
         public const string LOW_ARRIVING_BATCH_MODE = "LowPress";
         public const string DEFAULT_SCENARIO = "echo";
         public const string DEFAULT_OUTPUT_PATH = "counters.txt";
+        public const string DEFAULT_WEBAPP_HUB_URL = "http://localhost:5050/signalrbench";
 
         public class BenchConfigData
         {

--- a/SignalRServiceBenchmarkPlugin/src/signalr/Configuration/SimpleBenchmarkModelExtensions.cs
+++ b/SignalRServiceBenchmarkPlugin/src/signalr/Configuration/SimpleBenchmarkModelExtensions.cs
@@ -41,9 +41,9 @@ namespace Plugin.Microsoft.Azure.SignalR.Benchmark
             return configData.Kind == DEFAULT_KIND;
         }
 
-        public static bool isLongrun(this BenchConfigData configData)
+        public static bool isStrictPerf(this BenchConfigData configData)
         {
-            return configData.Kind == LONGRUN_KIND;
+            return configData.Kind == STRICTPERF_KIND;
         }
 
         public static bool isResultParser(this BenchConfigData configData)
@@ -54,9 +54,9 @@ namespace Plugin.Microsoft.Azure.SignalR.Benchmark
         public static ERRORCODE isValid(this BenchConfigData configData)
         {
             string error = null;
-            if (!configData.isLongrun() && !configData.isPerf() && !configData.isResultParser())
+            if (!configData.isStrictPerf() && !configData.isPerf() && !configData.isResultParser())
             {
-                error = $"Kind must be {DEFAULT_KIND} or {LONGRUN_KIND} or {PARSERESULT_KIND}, but see {configData.Kind}";
+                error = $"Kind must be {DEFAULT_KIND} or {STRICTPERF_KIND} or {PARSERESULT_KIND}, but see {configData.Kind}";
                 ErrorMap[ERRORCODE.InvalidKind] = error;
                 Log.Error(error);
                 return ERRORCODE.InvalidKind;

--- a/SignalRServiceBenchmarkPlugin/src/signalr/SignalRBenchmarkPlugin.cs
+++ b/SignalRServiceBenchmarkPlugin/src/signalr/SignalRBenchmarkPlugin.cs
@@ -17,11 +17,11 @@ namespace Plugin.Microsoft.Azure.SignalR.Benchmark
         private string _masterNamespaceSuffix = "MasterMethods";
         private string _agentNamespaceSuffix = "AgentMethods";
         private string _simpleConfigurationTemplate = $@"
-mode: simple                                                                         # Required: '{SimpleBenchmarkModel.DEFAULT_MODE}|{SimpleBenchmarkModel.ADVANCE_MODE}', default is '{SimpleBenchmarkModel.DEFAULT_MODE}'
-kind: perf                                                                           # Optional: '{SimpleBenchmarkModel.DEFAULT_KIND}|{SimpleBenchmarkModel.LONGRUN_KIND}|{SimpleBenchmarkModel.PARSERESULT_KIND}', default is '{SimpleBenchmarkModel.DEFAULT_KIND}'
+mode: simple                                                                         # Required: '{SimpleBenchmarkModel.DEFAULT_MODE}|{SimpleBenchmarkModel.ADVANCED_MODE}', default is '{SimpleBenchmarkModel.DEFAULT_MODE}'
+kind: perf                                                                           # Optional: '{SimpleBenchmarkModel.DEFAULT_KIND}|{SimpleBenchmarkModel.PARSERESULT_KIND}', default is '{SimpleBenchmarkModel.DEFAULT_KIND}'
 config:
   connectionString: Endpoint=https://xxxx.signalr.net;AccessKey=xxx;Version=1.0;     # Optional: if 'webAppTarget' has specified, this option will be ignored, otherwise you must specify it.
-  webAppTarget: http://localhost:5050/signalrbench                                   # Optional: if not specified, an internal webapp is launched on http://localhost:5050, hubname is 'signalrbench'
+  webAppTarget: http://localhost:5050/signalrbench                                   # Optional: if not specified, the default webapp url is assumed to be {SimpleBenchmarkModel.DEFAULT_WEBAPP_HUB_URL}
   connections: 1000                                                                  # Optional, default is {SimpleBenchmarkModel.DEFAULT_CONNECTIONS}
   arrivingRate: 50                                                                   # Optional, default is {SimpleBenchmarkModel.DEFAULT_ARRIVINGRATE}
   transport: Websockets                                                              # Optional: '{SimpleBenchmarkModel.DEFAULT_TRANSPORT}|{SimpleBenchmarkModel.SSE_TRANSPORT}|{SimpleBenchmarkModel.LONGPOLLING_TRANSPORT}', default is {SimpleBenchmarkModel.DEFAULT_TRANSPORT}
@@ -31,7 +31,6 @@ config:
   sendingSteps: 0                                                                    # Optional: maximum value is 'Connections / BaseSending', minimum value is 1. Default is 0, means getting from 'Connections / BaseSending'
   step: 500                                                                          # Optional: default is {SimpleBenchmarkModel.DEFAULT_STEP}
   connectionType: Core                                                               # Optional: '{SimpleBenchmarkModel.DEFAULT_CONNECTION_TYPE}|{SimpleBenchmarkModel.ASPNET_CONNECTION_TYPE}', default is '{SimpleBenchmarkModel.DEFAULT_CONNECTION_TYPE}', if you use AspNet SignalR, please choose '{SimpleBenchmarkModel.ASPNET_CONNECTION_TYPE}'.
-  arrivingBatchMode: HighPress                                                       # Optional: '{SimpleBenchmarkModel.DEFAULT_ARRIVING_BATCH_MODE}|{SimpleBenchmarkModel.LOW_ARRIVING_BATCH_MODE}', default is '{SimpleBenchmarkModel.DEFAULT_ARRIVING_BATCH_MODE}'
   debug: false                                                                       # Optional: dump more details if it is true, default is false
 scenario:
   name: echo                                                                         # Optional: '{SimpleBenchmarkModel.DEFAULT_SCENARIO}|broadcast|sendToGroup|sendToClient|restSendToUser|restSendToGroup|restBroadcast|restPersistSendToUser|restPersistSendToGroup|restPersistBroadcast', default is {SimpleBenchmarkModel.DEFAULT_SCENARIO}
@@ -40,6 +39,11 @@ scenario:
     sendingInterval: 1000                                                            # Optional: default is {SimpleBenchmarkModel.DEFAULT_SEND_INTERVAL} milliseconds
     groupCount: 500                                                                  # Optional: group count only valid for 'sendToGroup|restSendToGroup|restPersistSendToGroup', ignored for other scenarios
 ";
+
+        /**
+         * some other hidden properties:
+           arrivingBatchMode: HighPress                                             # Optional: '{SimpleBenchmarkModel.DEFAULT_ARRIVING_BATCH_MODE}|{SimpleBenchmarkModel.LOW_ARRIVING_BATCH_MODE}', default is '{SimpleBenchmarkModel.DEFAULT_ARRIVING_BATCH_MODE}'
+        */
         public IDictionary<string, object> PluginMasterParameters { get; set; } = new ConcurrentDictionary<string, object>();
 
         public IDictionary<string, object> PluginAgentParamaters { get; set; } = new ConcurrentDictionary<string, object>();

--- a/SignalRServiceBenchmarkPlugin/test/signalr/TestAllScenarios.cs
+++ b/SignalRServiceBenchmarkPlugin/test/signalr/TestAllScenarios.cs
@@ -10,7 +10,7 @@ namespace Plugin.Microsoft.Azure.SignalR.Benchmark.Tests
         {   
         }
 
-        #region simple perf
+        #region simple longrun
         [Fact]
         public async Task TestSendToGroup()
         {
@@ -103,9 +103,9 @@ config:
         }
         #endregion
 
-        #region simple longrun
+        #region simple perf
         [Fact]
-        public async Task TestEchoLongrun()
+        public async Task TestEchoPerf2()
         {
             _connections = 100;
             _sending = 100;
@@ -113,7 +113,7 @@ config:
             var arrvingRate = 10;
             var input = $@"
 mode: simple
-kind: longrun
+kind: perf2
 config:
   connectionString: Endpoint=https://dummy;AccessKey=dummy;Version=1.0; # Required
   singleStepDuration: {_duration}
@@ -126,7 +126,7 @@ config:
         }
 
         [Fact]
-        public async Task TestSendToGroupLongrun()
+        public async Task TestSendToGroupPerf2()
         {
             _connections = 100;
             _sending = 100;
@@ -135,7 +135,7 @@ config:
             var arrvingRate = 5;
             var input = $@"
 mode: simple
-kind: longrun
+kind: perf2
 config:
   connectionString: Endpoint=https://dummy;AccessKey=dummy;Version=1.0; # Required
   singleStepDuration: {_duration}
@@ -152,7 +152,7 @@ scenario:
         }
 
         [Fact]
-        public async Task TestSendToClientsLongrun()
+        public async Task TestSendToClientsPerf2()
         {
             _connections = 100;
             _sending = 100;
@@ -160,7 +160,7 @@ scenario:
             var arrvingRate = 5;
             var input = $@"
 mode: simple
-kind: longrun
+kind: perf2
 config:
   connectionString: Endpoint=https://dummy;AccessKey=dummy;Version=1.0; # Required
   singleStepDuration: {_duration}
@@ -175,7 +175,7 @@ scenario:
         }
 
         [Fact]
-        public async Task TestBroadcastLongrun()
+        public async Task TestBroadcastPerf2()
         {
             _connections = 10;
             _sending = 1;
@@ -183,7 +183,7 @@ scenario:
             var arrvingRate = 5;
             var input = $@"
 mode: simple
-kind: longrun
+kind: perf2
 config:
   connectionString: Endpoint=https://dummy;AccessKey=dummy;Version=1.0; # Required
   singleStepDuration: {_duration}
@@ -339,7 +339,7 @@ Types:
 - sendToGroup
 ";
             await _plugin.Start(input, _clients);
-            CheckResult(GetBenchResult());
+            CheckResult(GetBenchResult(output));
         }
         #endregion
 


### PR DESCRIPTION
hide some confused configurations, like longrun, highpress

dump cmd information

fix bug and test cases

when controller starts, it allows using builtin agent

fix bug for specifying many agents

fix a bug in unit test

parameters change for friendly usage

related issue #35 