### PR TITLE
dynamically tune the timedout per concurrent speed

### DIFF
--- a/scripts/func_env.sh
+++ b/scripts/func_env.sh
@@ -723,7 +723,8 @@ gen_all_tabs_4_report() {
   local html_id=$3
   local js_tgt_file=$4
   local desc="$5"
-  local postfix=`date +%Y%m%d%H%M%S`
+  local jobName=`echo "${JOB_NAME}"|tr ' ' '_'`
+  local postfix=${jobName}`date +%Y%m%d%H%M%S`
   local tmp_tabs=/tmp/tabs_${postfix}
   local js_refer_tmpl_file=/tmp/tabs_js_refer_${postfix}
   local i j

--- a/scripts/jenkins_functions.sh
+++ b/scripts/jenkins_functions.sh
@@ -28,8 +28,10 @@ function set_global_env() {
 ############ global static variables #########
    export RootFolder=$CurrentWorkingDir # some jekins already refers this
    #export ResultFolderSuffix='suffix'
-   export VMMgrDir=/tmp/VMMgr
-   export AspNetWebMgrDir=/tmp/AspNetWebMgr
+   local jobName=`echo "${JOB_NAME}"|tr ' ' '_'`
+   export JOBNAME_PREFIX=$jobName
+   export VMMgrDir=/tmp/${JOBNAME_PREFIX}VMMgr
+   export AspNetWebMgrDir=/tmp/${JOBNAME_PREFIX}AspNetWebMgr
    set_job_env
 }
 

--- a/scripts/jenkins_private_functions.sh
+++ b/scripts/jenkins_private_functions.sh
@@ -792,7 +792,7 @@ function run_and_gen_report() {
 
 function build_rpc_master() {
   local targetDir=$1
-  local tmpMaster=/tmp/master
+  local tmpMaster=/tmp/${JOBNAME_PREFIX}master
   if [ -e $tmpMaster ]
   then
      rm -rf $tmpMaster
@@ -817,7 +817,7 @@ function build_rpc_master() {
 
 function build_rpc_agent() {
   local targetDir=$1
-  local tmpAgent=/tmp/agent
+  local tmpAgent=/tmp/${JOBNAME_PREFIX}agent
   if [ -e $tmpAgent ]
   then
      rm -rf $tmpAgent
@@ -842,7 +842,7 @@ function build_rpc_agent() {
 
 build_app_server() {
   local targetDir=$1
-  local tmpAppServer=/tmp/appserver
+  local tmpAppServer=/tmp/${JOBNAME_PREFIX}appserver
   if [ -e $tmpAppServer ]
   then
      rm -rf $tmpAppServer

--- a/scripts/kubectl_utils.sh
+++ b/scripts/kubectl_utils.sh
@@ -377,12 +377,6 @@ function start_connection_tracking() {
   # collect connections
   while [ $SECONDS -lt $end ]
   do
-     # !do not always install net-tools which consumes too much CPU!
-     #result=$(k8s_query $resName $config_file)
-     #for i in $result
-     #do
-     #  kubectl exec --kubeconfig=$config_file $i apt-get install net-tools > /dev/null
-     #done
      for i in $result
      do
        local date_time=`date --iso-8601='seconds'`

--- a/src/signalr/AgentMethods/BatchConnectionBase.cs
+++ b/src/signalr/AgentMethods/BatchConnectionBase.cs
@@ -19,6 +19,7 @@ namespace Plugin.Microsoft.Azure.SignalR.Benchmark.AgentMethods
                 out int batchWaitMilliSeconds,
                 out SignalREnums.BatchMode mode);
             var packages = (from i in Enumerable.Range(0, connections.Count())
+                            where connections[i].GetStat() == SignalREnums.ConnectionInternalStat.Init
                             select (Connection: connections[i], LocalIndex: i)).ToList();
             // 100 milliseconds is the default fine-granularity
             var period = SignalRConstants.RateLimitDefaultGranularity;

--- a/src/signalr/MasterMethods/StartConnection.cs
+++ b/src/signalr/MasterMethods/StartConnection.cs
@@ -17,7 +17,7 @@ namespace Plugin.Microsoft.Azure.SignalR.Benchmark.MasterMethods
 
             // Get parameters
             stepParameters.TryGetTypedValue(SignalRConstants.ConcurrentConnection, out int concurrentConnection, Convert.ToInt32);
-
+            stepParameters.TryGetTypedValue(SignalRConstants.Type, out string type, Convert.ToString);
             if (concurrentConnection < clients.Count)
             {
                 concurrentConnection = clients.Count;
@@ -37,7 +37,13 @@ namespace Plugin.Microsoft.Azure.SignalR.Benchmark.MasterMethods
 
             var task = Task.WhenAll(results);
             // we wait until the default timeout reached
-            return Util.TimeoutCheckedTask(task, SignalRConstants.MillisecondsToWait, nameof(StartConnection));
+            long expectedMilliseconds = SignalRConstants.MillisecondsToWait;
+            if (SignalRUtils.FetchTotalConnectionFromContext(pluginParameters, type, out int totalConnections))
+            {
+                expectedMilliseconds = SignalRUtils.GetTimeoutPerConcurrentSpeed(totalConnections, concurrentConnection);
+            }
+
+            return Util.TimeoutCheckedTask(task, expectedMilliseconds, nameof(StartConnection));
         }
     }
 }


### PR DESCRIPTION
build master/agents on different folders

fix the race condition to modify the same file

avoid installing apt-get when running

regenerate the jobName