### PR TITLE
Simplify Jenkins project script

### DIFF
--- a/deploy/JenkinsPipeline.groovy
+++ b/deploy/JenkinsPipeline.groovy
@@ -1,0 +1,60 @@
+pipeline {
+    agent any
+    options {
+        disableConcurrentBuilds()
+    }
+    parameters {
+        string(name: 'BenchServerGroup', defaultValue: 'hz1wus2BenchResourceGroup', description: '')
+        string(name: 'VnetName', defaultValue: 'hz1wus2VNet', description: '')
+        string(name: 'SubnetName', defaultValue: 'hz1wus2Subnet', description: '')
+        string(name: 'clientVmCount', defaultValue: '1', description: '')
+        string(name: 'serverVmCount', defaultValue: '1', description: '')
+        string(name: 'nginx_server_dns', defaultValue: 'hz1wus2benchdns0.westus2.cloudapp.azure.com', description: '')
+        string(name: 'nginx_root', defaultValue: '/mnt/Data/NginxRoot', description: 'Stores performance results')
+        string(name: 'bench_send_size', defaultValue: '2048', description: '')
+        string(name: 'Sku', defaultValue: 'Basic_DS2', description: '')
+        string(name: 'g_nginx_ns', defaultValue: 'ingress-nginx', description: '')
+        string(name: 'copy_syslog', defaultValue: 'true', description: '')
+        string(name: 'copy_nginx_log', defaultValue: 'true', description: '')
+        string(name: 'VMLocation', defaultValue: 'westus2', description: '')
+        string(name: 'sigbench_run_duration', defaultValue: '1', description: '')
+        string(name: 'bench_config_hub', defaultValue: 'signalrbench', description: 'This is only used in gen_html.sh to display hub in html page')
+        string(name: 'bench_scenario_list', defaultValue: 'sendToClient', description: 'echo, broadcast, sendToClient')
+        string(name: 'bench_transport_list', defaultValue: 'Websockets', description: 'Valid transports: "Websockets" "LongPolling" "ServerSentEvents". Many transports are separated by whitespace')
+        string(name: 'bench_encoding_list', defaultValue: 'json', description: 'json, messagepack')
+        string(name: 'bench_serviceunit_list', defaultValue: '1', description: 'Dogfood instance size: "1 2 5 10 20 50 100"')
+        string(name: 'ASRSLocation', defaultValue: 'eastus', description: '')
+        string(name: 'useMaxConnection', defaultValue: 'false', description: '')
+        string(name: 'Disable_UNIT_PER_POD', defaultValue: 'false', description: '')
+        choice(name: 'ASRSEnv', choices: ['dogfood', 'production'], description: '')
+        string(name: 'Disable_Connection_Throttling', defaultValue: 'true', description: '')
+        string(name: 'sendToClientMsgSize', defaultValue: '256', description: '256 2k 16k 128k')
+        string(name: 'VMUser', defaultValue: 'wanl', description: '')
+        string(name: 'VMPassword', defaultValue: 'Adafserew#@145', description: '')
+    }
+    stages {
+        stage('Preparation') {
+            steps {
+                git branch: 'wanl/jenkins-run-script', url: 'https://github.com/Azure/azure-signalr-bench'
+            }        
+        }
+        stage('Build') {
+            options {
+                azureKeyVault([
+                    [envVariable: 'kubeconfig_srprodacswestus2k_json', name: 'kubeconfig-srprodacswestus2k-json', secretType: 'Secret'],
+                    [envVariable: 'kubeconfig_srdevacseastusa_json', name: 'kubeconfig-srdevacseastusa-json', secretType: 'Secret'],
+                    [envVariable: 'kubeconfig_srdevacsseasiaa_json', name: 'kubeconfig-srdevacsseasiaa-json', secretType: 'Secret'],
+                    [envVariable: 'sp_DF', name: 'sp-DF', secretType: 'Secret'],
+                    [envVariable: 'sp_INT', name: 'sp-INT', secretType: 'Secret'],
+                ])
+            }
+            steps {
+                sh label: '', script: '''# DO NOT edit the parameters in Jenkins Job above, unless you know what you are doing.
+                cd scripts && \\
+                source ./jenkins_job_run.sh &&\\
+                jenkins_job_run $GlobalResourceGroupPrefix $GlobalVmImageId $VMUser $VMPassword $VMLocation $clientVmCount $serverVmCount $nginx_root'''
+            }
+        }
+    }
+    
+}

--- a/scripts/jenkins_functions.sh
+++ b/scripts/jenkins_functions.sh
@@ -4,7 +4,7 @@
 # input Jenkinw workspace directory
 # this function is invoked in every job entry
 function set_global_env() {
-   local relative_dir="azure-signalr-bench"
+   local relative_dir="."
    local Jenkins_Workspace_Root=$1
    if [ $# -eq 2 ]
    then

--- a/scripts/jenkins_functions.sh
+++ b/scripts/jenkins_functions.sh
@@ -45,6 +45,35 @@ function write_az_credentials_to_create_vm() {
 
 # depends on set_global_env
 function set_job_env() {
+   # check required options
+   if [ -z "${sp_INT}"]; then
+     echo "Required option sp_INT is null or empty. Exit."
+     exit 1;
+   fi
+   if [ -z "${sp_DF}"]; then
+     echo "Required option sp_DF is null or empty. Exit."
+     exit 1;
+   fi
+   if [ -z "${kubeconfig_srprodacswestus2k_json}"]; then
+     echo "Required option kubeconfig_srprodacswestus2k_json is null or empty. Exit."
+     exit 1;
+   else
+     echo ${kubeconfig_srprodacswestus2k_json} > kubeconfig.srprodacswestus2k.json
+   fi
+   if [ -z "${kubeconfig_srdevacseastusa_json}"]; then
+     echo "Required option kubeconfig_srdevacseastusa_json is null or empty. Exit."
+     exit 1;
+   else
+     echo ${kubeconfig_srdevacseastusa_json} > kubeconfig.srdevacseastusa.json
+   fi
+   if [ -z "${kubeconfig_srdevacsseasiaa_json}"]; then
+     echo "Required option kubeconfig_srdevacsseasiaa_json is null or empty. Exit."
+     exit 1;
+   else
+     echo ${kubeconfig_srdevacsseasiaa_json} > kubeconfig.srdevacsseasiaa.json
+   fi
+   
+   # set optional options
    if [ "$nginx_root" == "" ]
    then
      export nginx_root=/mnt/Data/NginxRoot

--- a/scripts/jenkins_functions.sh
+++ b/scripts/jenkins_functions.sh
@@ -46,32 +46,39 @@ function write_az_credentials_to_create_vm() {
 # depends on set_global_env
 function set_job_env() {
    # check required options
-   if [ -z "${sp_INT}"]; then
+   set +x
+   if [ -z "${sp_INT}"]
+   then
      echo "Required option sp_INT is null or empty. Exit."
      exit 1;
    fi
-   if [ -z "${sp_DF}"]; then
+   if [ -z "${sp_DF}"]
+   then
      echo "Required option sp_DF is null or empty. Exit."
      exit 1;
    fi
-   if [ -z "${kubeconfig_srprodacswestus2k_json}"]; then
+   if [ -z "${kubeconfig_srprodacswestus2k_json}"]
+   then
      echo "Required option kubeconfig_srprodacswestus2k_json is null or empty. Exit."
      exit 1;
    else
      echo ${kubeconfig_srprodacswestus2k_json} > kubeconfig.srprodacswestus2k.json
    fi
-   if [ -z "${kubeconfig_srdevacseastusa_json}"]; then
+   if [ -z "${kubeconfig_srdevacseastusa_json}"]
+   then
      echo "Required option kubeconfig_srdevacseastusa_json is null or empty. Exit."
      exit 1;
    else
      echo ${kubeconfig_srdevacseastusa_json} > kubeconfig.srdevacseastusa.json
    fi
-   if [ -z "${kubeconfig_srdevacsseasiaa_json}"]; then
+   if [ -z "${kubeconfig_srdevacsseasiaa_json}"]
+   then
      echo "Required option kubeconfig_srdevacsseasiaa_json is null or empty. Exit."
      exit 1;
    else
      echo ${kubeconfig_srdevacsseasiaa_json} > kubeconfig.srdevacsseasiaa.json
    fi
+   set -x
    
    # set optional options
    if [ "$nginx_root" == "" ]

--- a/scripts/jenkins_job_run.sh
+++ b/scripts/jenkins_job_run.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+function jenkins_job_run() {
+    # input parameters
+    local resourceGroupPrefix=$1
+    local vmImageId=$2
+    local vmUser=$3
+    local vmPassword=$4
+    local vmLocation=$5
+    local clientVmCount=$6
+    local serverVmCount=$7
+    local nginx_root=$8
+
+    # import scripts
+    source ./jenkins_functions.sh
+    
+    # set root path
+    set_global_env $WORKSPACE
+
+    # generate random prefix of vm and resource grooup
+    resourceGroupPrefix="SignalRPerformance"
+    postfix=`date +%Y%m%d%H%M%S`
+    vmPrefix="${resourceGroupPrefix}${postfix}"
+
+    # configure agent
+    generate_vm_provison_config $vmImageId ${vmUser} ${vmPassword} ${vmPrefix} ${vmLocation} ${clientVmCount} ${serverVmCount}
+
+    # create VMs
+    dotnet run -p $RootFolder/JenkinsScript.csproj -- --PidFile="pid_create_vm.txt" --step=CreateAllVmsInSameVnet \
+    --VnetGroupName=$BenchServerGroup \
+    --VnetName=$VnetName \
+    --SubnetName=$SubnetName \
+    --AgentConfigFile=$AgentConfig \
+    --DisableRandomSuffix \
+    --ServicePrincipal=$ServicePrincipal
+
+    cat $PrivateIps
+    cat $PublicIps
+
+    # override the default environment
+cat << EOF >jenkins_env.sh
+nginx_root=$nginx_root
+sigbench_run_duration=$sigbench_run_duration
+EOF
+
+    set_global_env $WORKSPACE
+    set_job_env
+
+    # register exit handler to remove resource group ##
+    register_exit_handler
+
+    # run for all units
+    prepare_ASRS_creation
+
+    run_all_units ${vmUser} ${vmPassword}
+
+    ############# cleanup mail ##########
+    if [ -e /tmp/send_mail.txt ]
+    then
+    rm /tmp/send_mail.txt
+    fi
+
+    ## generate report
+    gen_final_report
+}
+

--- a/scripts/kubectl_utils.sh
+++ b/scripts/kubectl_utils.sh
@@ -2,7 +2,7 @@
 g_CPU_requests="1|2|3|4"
 g_CPU_limits="1|2|3|4"
 g_Memory_limits="4000|4000|4000|4000"
-g_k8s_config_list="${kubeconfig_srprodacswestus2k_json}|${kubeconfig_srdevacseastusa_json}|${kubeconfig_srdevacsseasiaa_json}"
+g_k8s_config_list="kubeconfig.srprodacswestus2k.json|kubeconfig.srdevacseastusa.json|kubeconfig.srdevacsseasiaa.json"
 
 if [ -e kubeconfig.extend ] && [ -s kubeconfig.extend ]
 then

--- a/scripts/kubectl_utils.sh
+++ b/scripts/kubectl_utils.sh
@@ -2,7 +2,7 @@
 g_CPU_requests="1|2|3|4"
 g_CPU_limits="1|2|3|4"
 g_Memory_limits="4000|4000|4000|4000"
-g_k8s_config_list="kubeconfig.srprodacswestus2k.json|kubeconfig.srdevacseastusa.json|kubeconfig.srdevacsseasiaa.json"
+g_k8s_config_list="${kubeconfig_srprodacswestus2k_json}|${kubeconfig_srdevacseastusa_json}|${kubeconfig_srdevacsseasiaa_json}"
 
 if [ -e kubeconfig.extend ] && [ -s kubeconfig.extend ]
 then

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -49,7 +49,7 @@ function az_login_signalr_dev_sub() {
 
 function az_login_ASRS_dogfood() {
   set +x
-  local servicePrincipal=$sp_DF # hard-code here: generate_clean_resource_script generate the script using this function
+  local servicePrincipal=$sp_DF
   read clientId clientSecret tenantId subscription < <(parse_service_principal "$servicePrincipal")
 
   az login --service-principal \
@@ -62,7 +62,7 @@ function az_login_ASRS_dogfood() {
 function az_signalr_dev_credentials() {
   set +x
   local outputFile=$1
-  local servicePrincipal=$sp_INT # hard-code here: generate_clean_resource_script generate the script using this function
+  local servicePrincipal=$sp_INT
   read clientId clientSecret tenantId subscription < <(parse_service_principal "$servicePrincipal")
 cat <<EOF > $outputFile
 clientId: $clientId

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+function az_login_signalr_dev_sub() {
+  set +x
+  az login --service-principal \
+            -u $AZURE_CLIENT_ID_INT \
+            --password $AZURE_CLIENT_SECRET_INT \
+            --tenant $AZURE_TENANT_ID_INT
+  set -x
+}
+
+function az_login_ASRS_dogfood() {
+  set +x
+  az login --service-principal \
+            -u $AZURE_CLIENT_ID_DF \
+            --password $AZURE_CLIENT_SECRET_DF \
+            --tenant $AZURE_TENANT_ID_DF
+  set -x
+}
+
+function az_signalr_dev_credentials() {
+  set +x
+  local outputFile=$1
+cat <<EOF > $outputFile
+clientId: $AZURE_CLIENT_ID_INT
+tenantId: $AZURE_TENANT_ID_INT
+clientSecret: $AZURE_CLIENT_SECRET_INT
+subscription: $AZURE_SUBSCRIPTION_ID_INT
+EOF
+  set -x
+}


### PR DESCRIPTION
1. Improve maintanance: most of the projects inside or accross bench server are using the same project running scripts with different parameters. Group as one script for easier usage.
1. Describe a project in jenkins pipeline script way to eaiser create, reuse or update without manually update in UI. The pipeline project can seperate stages, remember commits.
1. Put all the secrets except for one service principal (used to access azure key vault) to azure key vault. We can simpily update the secret's version in if needed.

[Sample project with jenkins pipeline](http://hz1wus2benchdns0.westus2.cloudapp.azure.com:8181/job/test-pipeline-demo) which is equal to the [original one](http://hz1wus2benchdns0.westus2.cloudapp.azure.com:8181/job/ASRS_Dogfood_Websockets_SendToClient_256_Nightly_Perf/).

Note that all the confiurations except for the Pipeline section in pipeline project are auto-generated based on jenkins pipeline script.

Todo:
1. better naming of the script
1. better naming to the parameters (some are global, so improve in another PR...)
1. separate script to 3 parts: creating VMs, running benchmark and generating report (looks some parts shares the same globall environment variables)